### PR TITLE
Bump regex-pcre-builtin

### DIFF
--- a/goldplate.cabal
+++ b/goldplate.cabal
@@ -37,7 +37,7 @@ Executable goldplate
     Glob                 >= 0.10 && < 0.11,
     optparse-applicative >= 0.14 && < 0.16,
     process              >= 1.6  && < 1.7,
-    regex-pcre-builtin   >= 0.95 && < 0.96,
+    regex-pcre-builtin   >= 0.95.1.3 && < 0.96,
     text                 >= 1.2  && < 1.3,
     time                 >= 1.8  && < 1.10,
     unordered-containers >= 0.2  && < 0.3

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: 'lts-15.6'
+resolver: 'lts-16.19'
 
 packages:
 - '.'

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 491387
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/15/6.yaml
-    sha256: 8d81505a6de861e167a58534ab62330afb75bfa108735c7db1204f7ef2a39d79
-  original: lts-15.6
+    size: 532177
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/19.yaml
+    sha256: d2b828ecf50386841d0c5700b58d38566992e10d63a062af497ab29ab031faa1
+  original: lts-16.19


### PR DESCRIPTION
Bump `regex-pcre-builtin` to latest version, so that this fix is included: https://github.com/audreyt/regex-pcre-builtin/pull/15