### PR TITLE
Add source-repository and description to .cabal file for `cabal check`.

### DIFF
--- a/goldplate.cabal
+++ b/goldplate.cabal
@@ -9,10 +9,20 @@ Copyright:     2019-2020 Fugue, Inc
 Category:      Language
 Build-type:    Simple
 Cabal-version: 1.18
+Description:   Language-agnostic golden test runner for command-line applications.
 
 Extra-source-files:
   CHANGELOG.md
   README.md
+
+Source-repository head
+  type:     git
+  location: git://github.com/fugue/goldplate.git
+
+Source-repository this
+  type:     git
+  location: git://github.com/fugue/goldplate.git
+  tag:      v0.1.3
 
 Executable goldplate
   Hs-source-dirs:    src


### PR DESCRIPTION
To satisfy `cabal check`, added missing sections to `goldplate.cabal`:
- `source-repository`
- `description`

The remaining warning is:
```
Warning: 'ghc-options: -O2' is rarely needed. Check that it is giving a real
benefit and not just imposing longer compile times on your users.
```
Consider removing `-O2`.
