### PR TITLE
Fix #13: portable stdin test

### DIFF
--- a/tests/stdin.goldplate
+++ b/tests/stdin.goldplate
@@ -1,5 +1,5 @@
 {
-    "command": "rev",
+    "command": "cat",
     "stdin": "hello world",
     "asserts": [
         {"exit_code": 0},

--- a/tests/stdin.stdout
+++ b/tests/stdin.stdout
@@ -1,1 +1,1 @@
-dlrow olleh
+hello world


### PR DESCRIPTION
Hopefully, `cat` works the same under all Unix flavors...