### PR TITLE
Bumps: GHC 9.0.1 to 9.0.2, text to 2.0, optparse-applicative to 0.17

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.13.20211116
+# version: 0.14
 #
-# REGENDATA ("0.13.20211116",["github","goldplate.cabal"])
+# REGENDATA ("0.14",["github","goldplate.cabal"])
 #
 name: Haskell-CI
 on:
@@ -33,10 +33,10 @@ jobs:
             compilerVersion: 9.2.1
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.0.1
+          - compiler: ghc-9.0.2
             compilerKind: ghc
-            compilerVersion: 9.0.1
-            setup-method: hvr-ppa
+            compilerVersion: 9.0.2
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.10.7
             compilerKind: ghc

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,3 +1,0 @@
--- on Linux we can use ghcup to setup (some) of jobs
--- hvr-ppa latest are 9.0.1 and 8.10.4
-ghcup-jobs: >= 9.2 || > 8.10.4 && < 9.0

--- a/goldplate.cabal
+++ b/goldplate.cabal
@@ -15,7 +15,7 @@ Description:   Language-agnostic golden test runner for command-line application
 
 Tested-with:
   GHC == 9.2.1
-  GHC == 9.0.1
+  GHC == 9.0.2
   GHC == 8.10.7
   GHC == 8.8.4
   GHC == 8.6.5
@@ -55,10 +55,10 @@ Executable goldplate
     directory            >= 1.3  && < 1.4,
     filepath             >= 1.4  && < 1.5,
     Glob                 >= 0.10 && < 0.11,
-    optparse-applicative >= 0.14 && < 0.17,
+    optparse-applicative >= 0.14 && < 0.18,
     process              >= 1.6  && < 1.7,
     regex-pcre-builtin   >= 0.95.1.3 && < 0.96,
-    text                 >= 1.2  && < 1.3,
+    text                 >= 1.2  && < 2.1,
     unordered-containers >= 0.2  && < 0.3
 
 Test-suite tests


### PR DESCRIPTION
- Bump CI from GHC 9.0.1 to 9.0.2
- allow `text-2.0`
- allow `optparse-applicative-0.17`

Context: https://github.com/commercialhaskell/stackage/issues/6428

I published these changes in revision 2, so no release necessary: https://hackage.haskell.org/package/goldplate-0.2.0/revisions/