### PR TITLE
Restrict Binaries workflow to master branch or manual dispatch

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -1,6 +1,13 @@
 name: Binaries
 
-on: ['pull_request', 'push']
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
@jaspervdj-luminal 
I noticed that the `Binaries` workflow runs twice in a PR always (once for the push to a branch, once for the PR sync).  
By restricting to branch `master` (see changed files), it would only run once for each PR update.
Would the artifact upload on `v`-tags still work?