### PR TITLE
Fix #29: use "/" in filepaths even under Windows

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -70,7 +70,7 @@ jobs:
 
     - name: Get goldplate version
       run: |
-        VERSION="$(stack run -- --numeric-version | tail -1)"
+        VERSION="$(${STACK} run -- --numeric-version | tail -1)"
         echo "VERSION=${VERSION}" >> "${GITHUB_ENV}"
 
     - name: Create artifact

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -27,12 +27,13 @@ jobs:
 
     - name: Restore ~/.stack and .stack-work
       uses: actions/cache/restore@v3
+      id:   cache
       with:
         path: |
           ~/.stack
           .stack-work
-        key:          "${{ runner.os }}-stack-${{ matrix.stack }}-ghc-${{ matrix.ghc }}-${{ hashFiles('goldplate.cabal', 'stack.yaml', 'stack.yaml.lock') }}"
-        restore-keys: "${{ runner.os }}-stack-${{ matrix.stack }}-ghc-${{ matrix.ghc }}-"
+        key:          ${{ runner.os }}-stack-${{ matrix.stack }}-ghc-${{ matrix.ghc }}-${{ hashFiles('goldplate.cabal', 'stack.yaml', 'stack.yaml.lock') }}
+        restore-keys: ${{ runner.os }}-stack-${{ matrix.stack }}-ghc-${{ matrix.ghc }}-
 
     - name: Setup Haskell Stack
       uses: haskell/actions/setup@v2
@@ -45,12 +46,18 @@ jobs:
 
     - name: Cache ~/.stack and .stack-work
       uses: actions/cache/save@v3
+      # Reevaluate key.
+      env:
+        key: ${{ runner.os }}-stack-${{ matrix.stack }}-ghc-${{ matrix.ghc }}-${{ hashFiles('goldplate.cabal', 'stack.yaml', 'stack.yaml.lock') }}
+      # Will fail if we already have a cache with this key.
+      if:   ${{ !(steps.cache.outputs.cache-hit && env.key == steps.cache.outputs.cache-matched-key) }}
       with:
         path: |
           ~/.stack
           .stack-work
-        key:          "${{ runner.os }}-stack-${{ matrix.stack }}-ghc-${{ matrix.ghc }}-${{ hashFiles('goldplate.cabal', 'stack.yaml', 'stack.yaml.lock') }}"
-      continue-on-error: true
+        key:  ${{ env.key }}
+      # Should not error.
+      # continue-on-error: true
 
     - name: Test
       run: stack test

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -17,19 +17,19 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
         stack: ["2.9.3"]
         ghc: ["9.2.5"]
 
     steps:
     - name: Get the version
       id: get_version
-      run: 'echo ::set-output name=version::${GITHUB_REF#refs/tags/}'
+      run: echo version="${GITHUB_REF#refs/tags/}" >> "${GITHUB_OUTPUT}"
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - uses: actions/cache@v2
-      name: Cache ~/.stack
+    - uses: actions/cache@v3
+      name: Cache ~/.stack and .stack-work
       with:
         path: |
           ~/.stack
@@ -38,7 +38,7 @@ jobs:
         restore-keys: "${{ runner.os }}-stack-${{ matrix.stack }}-ghc-${{ matrix.ghc }}-"
 
     - name: Setup Haskell Stack
-      uses: haskell/actions/setup@v1
+      uses: haskell/actions/setup@v2
       with:
         enable-stack: true
         stack-no-global: true
@@ -46,17 +46,26 @@ jobs:
     - name: Build
       run: stack build
 
+    - name: Test
+      run: stack test
+
     - name: Create artifact
-      if: startsWith(github.ref, 'refs/tags/v')
+      # if: startsWith(github.ref, 'refs/tags/v')
       run: |
-        PLATFORM=$(uname | tr 'A-Z' 'a-z')
-        VERSION=${{ steps.get_version.outputs.version }}
-        cp $(stack path --local-install-root)/bin/goldplate goldplate
-        tar -czf goldplate.tar.gz goldplate
+        PLATFORM="$(uname | tr 'A-Z' 'a-z')"
+        VERSION="${{ steps.get_version.outputs.version }}"
+        BIN_DIR="$(stack path --local-install-root)/bin"
+        EXE=$(cd "${BIN_DIR}"; ls goldplate*)
+        echo "PLATFORM = ${PLATFORM}"
+        echo "VERSION  = ${VERSION}"
+        echo "BIN_DIR  = ${BIN_DIR}"
+        echo "EXE      = ${EXE}"
+        cp "${BIN_DIR}/${EXE}" .
+        tar -czf goldplate.tar.gz "${EXE}"
         mkdir -p artifacts
         mv goldplate.tar.gz artifacts/goldplate-$VERSION-$PLATFORM-x86_64.tar.gz
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: startsWith(github.ref, 'refs/tags/v')
       with:
         path: artifacts/*
@@ -71,39 +80,20 @@ jobs:
     steps:
     - name: Get the version
       id: get_version
-      run: 'echo ::set-output name=version::${GITHUB_REF#refs/tags/}'
+      run: echo version="${GITHUB_REF#refs/tags/}" >> "${GITHUB_OUTPUT}"
 
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: artifacts
 
     - name: Display structure of downloaded files
       run: ls -R
 
-    - uses: actions/create-release@v1
-      id: create_release
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - uses: softprops/action-gh-release@v1
       with:
-        tag_name: ${{ steps.get_version.outputs.version }}
-        release_name: ${{ steps.get_version.outputs.version }}
-
-    - name: Upload Linux Asset
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./goldplate-${{ steps.get_version.outputs.version }}-linux-x86_64.tar.gz
-        asset_name: goldplate-${{ steps.get_version.outputs.version }}-linux-x86_64.tar.gz
-        asset_content_type: application/gzip
-
-    - name: Upload MacOS Asset
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./goldplate-${{ steps.get_version.outputs.version }}-darwin-x86_64.tar.gz
-        asset_name: goldplate-${{ steps.get_version.outputs.version }}-darwin-x86_64.tar.gz
-        asset_content_type: application/zip
+        token: ${{ secrets.GITHUB_TOKEN }}
+        files: |
+          goldplate-${{ steps.get_version.outputs.version }}-linux-x86_64.tar.gz
+          goldplate-${{ steps.get_version.outputs.version }}-darwin-x86_64.tar.gz
+          goldplate-${{ steps.get_version.outputs.version }}-windows-x86_64.tar.gz
+        generate_release_notes: true

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -25,8 +25,8 @@ jobs:
 
     - uses: actions/checkout@v3
 
-    - uses: actions/cache@v3
-      name: Cache ~/.stack and .stack-work
+    - name: Restore ~/.stack and .stack-work
+      uses: actions/cache/restore@v3
       with:
         path: |
           ~/.stack
@@ -42,6 +42,15 @@ jobs:
 
     - name: Build
       run: stack build
+
+    - name: Cache ~/.stack and .stack-work
+      uses: actions/cache/save@v3
+      with:
+        path: |
+          ~/.stack
+          .stack-work
+        key:          "${{ runner.os }}-stack-${{ matrix.stack }}-ghc-${{ matrix.ghc }}-${{ hashFiles('goldplate.cabal', 'stack.yaml', 'stack.yaml.lock') }}"
+      continue-on-error: true
 
     - name: Test
       run: stack test

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -33,17 +33,6 @@ jobs:
 
     - uses: actions/checkout@v3
 
-    - name: Setup MSYS2 (Windows)
-      if:   ${{ runner.os == 'Windows' }}
-      run:  echo "C:\msys64\mingw64\bin;C:\msys64\usr\bin" >> "${GITHUB_PATH}"
-
-    - name: Info about command-line tools used in test-suite
-      run:  |
-        which bash
-        which cat
-        which echo
-      continue-on-error: true
-
     - name: Setup Haskell Stack
       uses: haskell/actions/setup@v2
       id:   setup
@@ -75,6 +64,38 @@ jobs:
         key:  ${{ env.key }}
       # Should not error.
       # continue-on-error: true
+
+    - name: Info about command-line tools used in test-suite
+      run:  |
+        which bash
+        which cat
+        which echo
+      continue-on-error: true
+
+    - name: Info about command-line tools used in test-suite (via stack exec)
+      run:  |
+        ${STACK} exec which bash
+        ${STACK} exec which cat
+        ${STACK} exec which echo
+      continue-on-error: true
+
+    - name: Setup MSYS2 (Windows)
+      if:   ${{ runner.os == 'Windows' }}
+      run:  echo "C:\msys64\mingw64\bin;C:\msys64\usr\bin" >> "${GITHUB_PATH}"
+
+    - name: Info about command-line tools used in test-suite
+      run:  |
+        which bash
+        which cat
+        which echo
+      continue-on-error: true
+
+    - name: Info about command-line tools used in test-suite (via stack exec)
+      run:  |
+        ${STACK} exec which bash
+        ${STACK} exec which cat
+        ${STACK} exec which echo
+      continue-on-error: true
 
     - name: Test
       run: ${STACK} test --test-arguments --diff

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -41,7 +41,7 @@ jobs:
         stack-version: ${{ matrix.stack }}
         ghc-version:   ${{ matrix.ghc   }}
 
-    - name: Restore ~/.stack
+    - name: Restore cache
       uses: actions/cache/restore@v3
       id:   cache
       with:
@@ -52,7 +52,7 @@ jobs:
     - name: Build
       run: ${STACK} build
 
-    - name: Cache ~/.stack
+    - name: Save cache
       uses: actions/cache/save@v3
       # Reevaluate key.
       env:
@@ -66,7 +66,7 @@ jobs:
       # continue-on-error: true
 
     - name: Test
-      run: ${STACK} test
+      run: ${STACK} test --test-arguments --diff
 
     - name: Get goldplate version
       run: |

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -20,31 +20,34 @@ jobs:
         os: [ubuntu-latest, macOS-latest, windows-latest]
         stack: ["2.9.3"]
         ghc: ["9.2.5"]
+          # The GHC version has to match the one in the stack.yaml file.
+    env:
+      STACK: "stack --system-ghc"
 
     steps:
 
     - uses: actions/checkout@v3
 
-    - name: Restore ~/.stack and .stack-work
+    - name: Setup Haskell Stack
+      uses: haskell/actions/setup@v2
+      id:   setup
+      with:
+        enable-stack:  true
+        stack-version: ${{ matrix.stack }}
+        ghc-version:   ${{ matrix.ghc   }}
+
+    - name: Restore ~/.stack
       uses: actions/cache/restore@v3
       id:   cache
       with:
-        path: |
-          ~/.stack
-          .stack-work
+        path:         ${{ steps.setup.outputs.stack-root }}
         key:          ${{ runner.os }}-stack-${{ matrix.stack }}-ghc-${{ matrix.ghc }}-${{ hashFiles('goldplate.cabal', 'stack.yaml', 'stack.yaml.lock') }}
         restore-keys: ${{ runner.os }}-stack-${{ matrix.stack }}-ghc-${{ matrix.ghc }}-
 
-    - name: Setup Haskell Stack
-      uses: haskell/actions/setup@v2
-      with:
-        enable-stack: true
-        stack-no-global: true
-
     - name: Build
-      run: stack build
+      run: ${STACK} build
 
-    - name: Cache ~/.stack and .stack-work
+    - name: Cache ~/.stack
       uses: actions/cache/save@v3
       # Reevaluate key.
       env:
@@ -52,15 +55,13 @@ jobs:
       # Will fail if we already have a cache with this key.
       if:   ${{ !(steps.cache.outputs.cache-hit && env.key == steps.cache.outputs.cache-matched-key) }}
       with:
-        path: |
-          ~/.stack
-          .stack-work
+        path: ${{ steps.setup.outputs.stack-root }}
         key:  ${{ env.key }}
       # Should not error.
       # continue-on-error: true
 
     - name: Test
-      run: stack test
+      run: ${STACK} test
 
     - name: Get goldplate version
       run: |
@@ -71,7 +72,7 @@ jobs:
       # if: startsWith(github.ref, 'refs/tags/v')
       run: |
         PLATFORM="$(uname | tr 'A-Z' 'a-z')"
-        BIN_DIR="$(stack path --local-install-root)/bin"
+        BIN_DIR="$(${STACK} path --local-install-root)/bin"
         EXE=$(cd "${BIN_DIR}"; ls goldplate*)
         echo "PLATFORM = ${PLATFORM}"
         echo "VERSION  = ${VERSION}"

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -11,11 +11,16 @@ on:
       - master
   workflow_dispatch:
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build:
     name: Build on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
         stack: ["2.9.3"]

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -22,9 +22,6 @@ jobs:
         ghc: ["9.2.5"]
 
     steps:
-    - name: Get the version
-      id: get_version
-      run: echo version="${GITHUB_REF#refs/tags/}" >> "${GITHUB_OUTPUT}"
 
     - uses: actions/checkout@v3
 
@@ -49,11 +46,15 @@ jobs:
     - name: Test
       run: stack test
 
+    - name: Get goldplate version
+      run: |
+        VERSION="$(stack run -- --numeric-version | tail -1)"
+        echo "VERSION=${VERSION}" >> "${GITHUB_ENV}"
+
     - name: Create artifact
       # if: startsWith(github.ref, 'refs/tags/v')
       run: |
         PLATFORM="$(uname | tr 'A-Z' 'a-z')"
-        VERSION="${{ steps.get_version.outputs.version }}"
         BIN_DIR="$(stack path --local-install-root)/bin"
         EXE=$(cd "${BIN_DIR}"; ls goldplate*)
         echo "PLATFORM = ${PLATFORM}"
@@ -63,24 +64,27 @@ jobs:
         cp "${BIN_DIR}/${EXE}" .
         tar -czf goldplate.tar.gz "${EXE}"
         mkdir -p artifacts
-        mv goldplate.tar.gz artifacts/goldplate-$VERSION-$PLATFORM-x86_64.tar.gz
+        mv goldplate.tar.gz "artifacts/goldplate-${VERSION}-${PLATFORM}-x86_64.tar.gz"
 
     - uses: actions/upload-artifact@v3
-      if: startsWith(github.ref, 'refs/tags/v')
+      # if: startsWith(github.ref, 'refs/tags/v')
       with:
         path: artifacts/*
         name: artifacts
+
+    outputs:
+      version: ${{ env.VERSION }}
 
   release:
     name: Release
     needs: build
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
+    # if: startsWith(github.ref, 'refs/tags/v')
 
     steps:
-    - name: Get the version
-      id: get_version
-      run: echo version="${GITHUB_REF#refs/tags/}" >> "${GITHUB_OUTPUT}"
+    # - name: Get the version
+    #   id: get_version
+    #   run: echo version="${GITHUB_REF#refs/tags/}" >> "${GITHUB_OUTPUT}"
 
     - uses: actions/download-artifact@v3
       with:
@@ -90,10 +94,12 @@ jobs:
       run: ls -R
 
     - uses: softprops/action-gh-release@v1
+      env:
+        VERSION: ${{ needs.build.outputs.version }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         files: |
-          goldplate-${{ steps.get_version.outputs.version }}-linux-x86_64.tar.gz
-          goldplate-${{ steps.get_version.outputs.version }}-darwin-x86_64.tar.gz
-          goldplate-${{ steps.get_version.outputs.version }}-windows-x86_64.tar.gz
+          goldplate-${{ env.VERSION }}-linux-x86_64.tar.gz
+          goldplate-${{ env.VERSION }}-darwin-x86_64.tar.gz
+          goldplate-${{ env.VERSION }}-windows-x86_64.tar.gz
         generate_release_notes: true

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -33,6 +33,17 @@ jobs:
 
     - uses: actions/checkout@v3
 
+    - name: Setup MSYS2 (Windows)
+      if:   ${{ runner.os == 'Windows' }}
+      run:  echo "C:\msys64\mingw64\bin;C:\msys64\usr\bin" >> "${GITHUB_PATH}"
+
+    - name: Info about command-line tools used in test-suite
+      run:  |
+        which bash
+        which cat
+        which echo
+      continue-on-error: true
+
     - name: Setup Haskell Stack
       uses: haskell/actions/setup@v2
       id:   setup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+ -  0.3.0 (2023-02-11)
+     *  Use `/` as path separator even under Windows (by Andreas Abel)
+
  -  0.2.1.1 (2023-02-26)
      *  Bump `aeson` dependency upper bound to 2.1.
      *  Tested with GHC 8.4 - 9.6.1 alpha3.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
  -  0.3.0 (2023-02-11)
      *  Use `/` as path separator even under Windows (by Andreas Abel)
+     *  Add option `--numeric-version` (by Andreas Abel)
 
  -  0.2.1.1 (2023-02-26)
      *  Bump `aeson` dependency upper bound to 2.1.

--- a/goldplate.cabal
+++ b/goldplate.cabal
@@ -1,5 +1,5 @@
 Name:          goldplate
-Version:       0.2.1.1
+Version:       0.3.0
 Synopsis:      A lightweight golden test runner
 License:       Apache-2.0
 License-file:  LICENSE
@@ -36,7 +36,7 @@ Source-repository head
 Source-repository this
   type:     git
   location: https://github.com/jaspervdj/goldplate.git
-  tag:      v0.2.1.1
+  tag:      v0.3.0
 
 Library
   Hs-source-dirs:    src

--- a/src/Goldplate.hs
+++ b/src/Goldplate.hs
@@ -230,7 +230,7 @@ specExecutions specPath spec = do
             inputFiles <- Dir.withCurrentDirectory workDirectory $ do
                 matches <- globCurrentDir glob
                 length matches `seq` return matches
-            return (map (Just . FP.normalise) inputFiles)
+            return (map (Just . normalise) inputFiles)
 
     -- Create an execution for every concrete input.
     forM concreteInputFiles $ \mbInputFile -> do
@@ -257,6 +257,15 @@ specExecutions specPath spec = do
     hoistEither :: Either MissingEnvVar a -> IO a
     hoistEither = either throwIO return
 
+    -- A version of FP.normalise that uses slash as 'pathSeparator' even under Windows.
+    -- Drops "." directories in the path.
+    -- Should make test outputs that contain filepaths more portable.
+    -- Assumes that the argument is a file rather than a directory.
+    -- This frees us from corner cases such as "." and "./".
+    normalise :: FilePath -> FilePath
+    normalise = List.intercalate "/" . dropDots . FP.splitDirectories
+      where
+        dropDots = filter ("." /=)
 
 executionHeader :: Execution -> String
 executionHeader execution =

--- a/src/Goldplate.hs
+++ b/src/Goldplate.hs
@@ -500,7 +500,7 @@ parseOptions = Options
             OA.help    "Number of worker jobs")
 
 parserInfo :: OA.ParserInfo Options
-parserInfo = OA.info (OA.helper <*> versionOption <*> parseOptions) $
+parserInfo = OA.info (OA.helper <*> versionOption <*> numericVersionOption <*> parseOptions) $
     OA.fullDesc <>
     OA.header goldplateVersion
   where
@@ -510,7 +510,14 @@ parserInfo = OA.info (OA.helper <*> versionOption <*> parseOptions) $
     OA.help    "Show version info" <>
     OA.hidden
   goldplateVersion :: String
-  goldplateVersion = "goldplate v" <> showVersion version
+  goldplateVersion = "goldplate v" <> goldplateNumericVersion
+
+  numericVersionOption = OA.infoOption goldplateNumericVersion $
+    OA.long    "numeric-version" <>
+    OA.help    "Show version number" <>
+    OA.hidden
+  goldplateNumericVersion :: String
+  goldplateNumericVersion = showVersion version
 
 --------------------------------------------------------------------------------
 

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -1,9 +1,12 @@
 {-# LANGUAGE OverloadedStrings #-}
+
 module Main (main) where
+
 import qualified Data.Aeson            as A
 import           Data.ByteString.Char8 ()
 import qualified Data.List             as List
 import           Goldplate             (Assert)
+import           System.Environment    (getArgs)
 import           System.Exit           (exitWith)
 import           System.Process        (system)
 
@@ -19,5 +22,7 @@ testAssertMultipleDiscriminator =
 
 main :: IO ()
 main = do
-    testAssertMultipleDiscriminator
-    exitWith =<< system ("goldplate tests")
+  testAssertMultipleDiscriminator
+  args <- getArgs
+  exitWith =<< do
+    system $ unwords $ "goldplate tests" : args


### PR DESCRIPTION
Fix #29: use / in filepaths even under Windows
    
`System.FilePath.normalise` replaces slashes by backslashes.
We implement a simplified version of `normalise` that does the opposite.
    
This should make (relative) file path printed in test output more portable across OSs.

(The two commits are meaningful individually and have been tested locally.)