### PR TITLE
Reorganize to allow for Haskell tests

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -1,0 +1,6 @@
+module Main (main) where
+
+import qualified Goldplate
+
+main :: IO ()
+main = Goldplate.main

--- a/goldplate.cabal
+++ b/goldplate.cabal
@@ -36,11 +36,11 @@ Source-repository this
   location: https://github.com/fugue/goldplate.git
   tag:      v0.2.1.1
 
-Executable goldplate
+Library
   Hs-source-dirs:    src
-  Main-is:           Main.hs
   Default-language:  Haskell2010
-  Ghc-options:       -Wall -rtsopts -threaded
+  Ghc-options:       -Wall
+  Exposed-modules:   Goldplate
 
   Other-modules:
     Text.Regex.PCRE.Simple
@@ -48,26 +48,32 @@ Executable goldplate
     Paths_goldplate
 
   Build-depends:
-    aeson                >= 1.4  && < 2.3,
-    aeson-pretty         >= 0.8  && < 0.9,
-    async                >= 2.2  && < 2.3,
-    base                 >= 4.11 && < 5,
-    bytestring           >= 0.10 && < 0.13,
-    Diff                 >= 0.3  && < 0.5,
-    directory            >= 1.3  && < 1.4,
-    filepath             >= 1.4  && < 1.5,
-    Glob                 >= 0.10 && < 0.11,
-    optparse-applicative >= 0.14 && < 0.19,
-    process              >= 1.6  && < 1.7,
+    aeson                >= 1.4      && < 2.3,
+    aeson-pretty         >= 0.8      && < 0.9,
+    async                >= 2.2      && < 2.3,
+    base                 >= 4.11     && < 5,
+    bytestring           >= 0.10     && < 0.13,
+    Diff                 >= 0.3      && < 0.5,
+    directory            >= 1.3      && < 1.4,
+    filepath             >= 1.4      && < 1.5,
+    Glob                 >= 0.10     && < 0.11,
+    optparse-applicative >= 0.14     && < 0.19,
+    process              >= 1.6      && < 1.7,
     regex-pcre-builtin   >= 0.95.1.3 && < 0.96,
-    text                 >= 1.2  && < 2.1,
-    unordered-containers >= 0.2  && < 0.3
+    text                 >= 1.2      && < 2.1,
+    unordered-containers >= 0.2      && < 0.3
+
+Executable goldplate
+  Main-is:           Main.hs
+  Default-language:  Haskell2010
+  Ghc-options:       -Wall -rtsopts -threaded
+  Build-depends:     base, goldplate
 
 Test-suite tests
   Default-language:   Haskell2010
   Type:               exitcode-stdio-1.0
-  Ghc-options:        -threaded
+  Ghc-options:        -Wall -threaded
   Main-is:            Tests.hs
-  Build-depends:      base, process
   Build-tool-depends: goldplate:goldplate
   Hs-source-dirs:     tests
+  Build-depends:      base, process

--- a/src/Goldplate.hs
+++ b/src/Goldplate.hs
@@ -7,7 +7,7 @@
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-module Main
+module Goldplate
     ( main
     ) where
 

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -1,5 +1,6 @@
-import System.Exit     ( exitWith  )
-import System.Process  ( system    )
+module Main (main) where
+import           System.Exit    (exitWith)
+import           System.Process (system)
 
 main :: IO ()
 main = exitWith =<< system ("goldplate tests")


### PR DESCRIPTION
This builds goldplate as a library first.  This allows us to write Haskell tests where we import this library in addition to the golden tests we have already.